### PR TITLE
Let pyrosl.ROSL find librosl.so.0.2, update variable names in example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -54,7 +54,7 @@ ss_rosl = pyrosl.ROSL(
     iters = 100,
     verbose = True
 )
-ss_rosl.fit_transform(X)
+ss_loadings = ss_rosl.fit_transform(X)
 
 # Run the full ROSL algorithm
 print ' '
@@ -64,11 +64,11 @@ full_rosl = pyrosl.ROSL(
     reg = regROSL,
     verbose = True
    )
-full_rosl.fit_transform(X)
+full_loadings = full_rosl.fit_transform(X)
 
 # Output some numbers
-ssmodel = np.dot(ss_rosl.basis_,ss_rosl.coeffs_)
-fullmodel = np.dot(full_rosl.basis_,full_rosl.coeffs_)
+ssmodel = np.dot(ss_loadings, ss_rosl.components_)
+fullmodel = np.dot(full_loadings, full_rosl.components_)
 
 error1 = np.linalg.norm(R - ssmodel, 'fro') / np.linalg.norm(R, 'fro')
 error2 = np.linalg.norm(R - fullmodel, 'fro') / np.linalg.norm(R, 'fro')

--- a/pyrosl.py
+++ b/pyrosl.py
@@ -61,7 +61,7 @@ class ROSL(object):
         self.tol = tol
         self.iters = iters
         self.verbose = verbose
-        libpath = os.path.dirname(os.path.relpath(__file__)) + '/librosl.so.0.2'
+        libpath = os.path.dirname(os.path.abspath(__file__)) + '/librosl.so.0.2'
         self._pyrosl = ctypes.cdll.LoadLibrary(libpath).pyROSL
         self._pyrosl.restype = ctypes.c_int
         self._pyrosl.argtypes = [
@@ -110,7 +110,7 @@ class ROSL(object):
         """
         
         loadings, components, error = self._fit(X)
-        loadings = loadings[:, self.rank_]
+        loadings = loadings[:, :self.rank_]
         
         return loadings
     


### PR DESCRIPTION
The relative path method failed when pyrosl was not imported as a
submodule (e.g. when example.py is run from the command line). It now
searches for an absolute path.
